### PR TITLE
ci(workflows): assign explicit permissions

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,6 +1,9 @@
 name: "auto-merge"
 on: [pull_request_target]
 
+# No GITHUB_TOKEN permissions, as we use AUTOMERGE_TOKEN instead.
+permissions: {}
+
 jobs:
   auto-merge:
     uses: mdn/workflows/.github/workflows/auto-merge.yml@main

--- a/.github/workflows/idle.yml
+++ b/.github/workflows/idle.yml
@@ -6,6 +6,12 @@ on:
   schedule:
     - cron: "0 8 * * *"
 
+# See: https://github.com/actions/stale#recommended-permissions
+permissions:
+  actions: write
+  issues: write
+  pull-requests: write
+
 jobs:
   mark-as-idle:
     uses: mdn/workflows/.github/workflows/idle.yml@main

--- a/.github/workflows/idle.yml
+++ b/.github/workflows/idle.yml
@@ -6,12 +6,6 @@ on:
   schedule:
     - cron: "0 8 * * *"
 
-# See: https://github.com/actions/stale#recommended-permissions
-permissions:
-  actions: write
-  issues: write
-  pull-requests: write
-
 jobs:
   mark-as-idle:
     uses: mdn/workflows/.github/workflows/idle.yml@main


### PR DESCRIPTION
### Description

Adds explicit `permissions:` configuration to workflow files that don't already have permissions defined either at the workflow level or for all jobs.

- If the workflow doesn't use `secrets.GITHUB_TOKEN` or `github.token`, sets `permissions: {}` to restrict all permissions.
- If the workflow uses the GitHub token, adds `permissions:` with required permissions.

### Motivation

Security best practice to explicitly declare `GITHUB_TOKEN` permissions instead of relying on default permissions, following the principle of least privilege by ensuring workflows only have the permissions they actually need.

### Additional details

See: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/924.
