### PR TITLE
ci(workflows): pin 3rd party actions

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -26,12 +26,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: 22
           package-manager-cache: false
@@ -43,14 +43,14 @@ jobs:
         run: npm run build
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           # Upload dist folder only
           path: "./dist"
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
### Description

Pins all 3rd party GitHub Actions to specific commit hashes instead of version tags.

Each pinned action includes an inline comment with the resolved version number for reference.

### Motivation

Security best practice to pin actions to immutable commit hashes, preventing potential supply chain attacks from compromised action versions or tag hijacking.

### Additional details

See: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1005.