### PR TITLE
ci(workflows): use latest compatible node version

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -34,6 +34,7 @@ jobs:
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version-file: .nvmrc
+          check-latest: true
           package-manager-cache: false
 
       - name: Install deps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version-file: .nvmrc
+          check-latest: true
           cache: npm
 
       - name: Install
@@ -41,6 +42,7 @@ jobs:
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version-file: .nvmrc
+          check-latest: true
           cache: npm
 
       - name: Install
@@ -65,6 +67,7 @@ jobs:
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version-file: .nvmrc
+          check-latest: true
           cache: npm
 
       - name: Install


### PR DESCRIPTION
### Description

Updates all workflow steps using `actions/setup-node`, setting `check-latest: true`.

### Motivation

Ensures the latest compatible Node version is used consistently, with the corresponding npm version.

### Additional details


### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1309.
