### PR TITLE
ci(auto-merge): sync workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,13 +1,14 @@
-name: "auto-merge"
-on: [pull_request_target]
+name: auto-merge
 
-# No GITHUB_TOKEN permissions, as we use AUTOMERGE_TOKEN instead.
-permissions: {}
+on:
+  pull_request_target:
+
+permissions:
+  contents: read
 
 jobs:
   auto-merge:
+    if: github.repository_owner == 'mdn'
     uses: mdn/workflows/.github/workflows/auto-merge.yml@main
-    with:
-      target-repo: "mdn/client-toolchain-example"
     secrets:
       GH_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -10,5 +10,7 @@ jobs:
   auto-merge:
     if: github.repository_owner == 'mdn'
     uses: mdn/workflows/.github/workflows/auto-merge.yml@main
+    with:
+      auto-merge: true
     secrets:
       GH_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}


### PR DESCRIPTION
### Description

Syncs the `auto-merge.yml` workflow:

- Sets `permissions: { contents: read }`
- Sets `auto-merge: true`
- Removes the obsolete `target-repo` input in favor of `if: github.repository_owner == 'mdn'`


### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1395.
